### PR TITLE
[WIP] center window on first start only, then restore from user defaults

### DIFF
--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -1,5 +1,9 @@
 import Cocoa
 
+extension NSWindow.FrameAutosaveName {
+	static let preferences: NSWindow.FrameAutosaveName = "com.sindresorhus.Preferences.FrameAutosaveName-WIP-1"
+}
+
 public final class PreferencesWindowController: NSWindowController {
 	private let tabViewController = PreferencesTabViewController()
 
@@ -60,12 +64,22 @@ public final class PreferencesWindowController: NSWindowController {
 	/// - Note: Unless you need to open a specific pane, prefer not to pass a parameter at all
 	/// - Parameter preferencePane: Identifier of the preference pane to display.
 	public func show(preferencePane preferenceIdentifier: PreferencePaneIdentifier? = nil) {
-		if !window!.isVisible {
-			window?.center()
-		}
-
+		centerWindowOnFirstStart()
 		showWindow(self)
 		tabViewController.activateTab(preferenceIdentifier: preferenceIdentifier, animated: false)
 		NSApp.activate(ignoringOtherApps: true)
+	}
+
+	private func centerWindowOnFirstStart() {
+		guard let window = self.window else {
+			return
+		}
+
+		// When setting the autosave name, the current position isn't stored immediately.
+		// Trying to read the frame values will fail, so we can center it.
+		window.setFrameAutosaveName(.preferences)
+		if window.setFrameUsingName(.preferences) == false {
+			window.center()
+		}
 	}
 }


### PR DESCRIPTION
Eventually closes #22. It does restore _something_, but it doesn't appear to be the frame rectangle when you close the app :) On my machine, when I put the window in the top-right corner, on subsequent launches the window will gradually restore further towards the lower-left.

Will have to investigate further. So far I found that

- `activateTab` interferes with the restoration
- deactivate centering will make the window move down, but fix it moving left

Posting this W.I.P. in case somebody else has an idea in the meantime.