### PR TITLE
WIP: Fix preferences window not appearing when the content views are not using auto-layout

### DIFF
--- a/Sources/Preferences/PreferencePane.swift
+++ b/Sources/Preferences/PreferencePane.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-public struct PreferencePaneIdentifier: Hashable, RawRepresentable {
+public struct PreferencePaneIdentifier: Hashable, RawRepresentable, Codable {
 	public typealias Identifier = PreferencePaneIdentifier
 
 	public let rawValue: String

--- a/Sources/Preferences/PreferencePane.swift
+++ b/Sources/Preferences/PreferencePane.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-public struct PreferencePaneIdentifier: Equatable, RawRepresentable {
+public struct PreferencePaneIdentifier: Equatable, Hashable, RawRepresentable {
 	public typealias Identifier = PreferencePaneIdentifier
 
 	public let rawValue: String

--- a/Sources/Preferences/PreferencePane.swift
+++ b/Sources/Preferences/PreferencePane.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-public struct PreferencePaneIdentifier: Equatable, Hashable, RawRepresentable {
+public struct PreferencePaneIdentifier: Hashable, RawRepresentable {
 	public typealias Identifier = PreferencePaneIdentifier
 
 	public let rawValue: String

--- a/Sources/Preferences/PreferencePane.swift
+++ b/Sources/Preferences/PreferencePane.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-public struct PreferencePaneIdentifier: Equatable, RawRepresentable {
+public struct PreferencePaneIdentifier: Equatable, RawRepresentable, Hashable {
 	public let rawValue: String
 
 	public init(rawValue: String) {

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -63,7 +63,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			activeTab = index
 			preferencesStyleController.selectTab(index: index)
 			updateWindowTitle(tabIndex: index)
-			setWindowFrame(for: preferencePanes[index].viewController, animated: animated)
+			setWindowFrame(for: preferencePanes[index], animated: animated)
 		}
 
 		if activeTab == nil {
@@ -146,7 +146,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	private func setWindowFrame(for viewController: NSViewController, animated: Bool = false) {
 		guard
 			let window = window,
-			let preferencePane = preferencePanes.first(where: { $0.viewController == viewController })
+			let preferencePane = preferencePanes.first(where: { $0 == viewController })
 		else {
 			preconditionFailure()
 		}

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -202,7 +202,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			contentSize = cachedSize
 			print("cached size used: \(contentSize)")
 		} else {
-			viewController.view.needsLayout = true
+//			viewController.view.needsUpdateConstraints = true
 			contentSize = viewController.view.fittingSize
 			print("contentSize pass 1: \(contentSize)")
 			if contentSize == .zero {
@@ -210,7 +210,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 				print("contentSize pass 2: \(contentSize)")
 			}
 
-			print("contentSize preferred size pass: \(viewController.preferredContentSize)")
+			print("contentSize bounds size pass: \(viewController.view.bounds.size)")
 			self.viewSizeCache[preferencePane.preferencePaneIdentifier] = contentSize
 			print("size added to cache: \(contentSize)")
 		}

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -209,7 +209,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 				print("contentSize pass 2: \(contentSize)")
 			}
 
-			print("contentSize intrinsic size pass: \(viewController.view.intrinsicContentSize)")
+			print("contentSize preferred size pass: \(viewController.preferredContentSize)")
 			self.viewSizeCache[preferencePane.preferencePaneIdentifier] = contentSize
 			print("size added to cache: \(contentSize)")
 		}

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -13,9 +13,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 
 	private var viewSizeCache = [PreferencePaneIdentifier: CGSize]()
 
-	var window: NSWindow! {
-		return view.window
-	}
+	var window: NSWindow! { view.window }
 
 	override func loadView() {
 		self.view = NSView()

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -202,6 +202,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			contentSize = cachedSize
 			print("cached size used: \(contentSize)")
 		} else {
+			viewController.view.needsLayout = true
 			contentSize = viewController.view.fittingSize
 			print("contentSize pass 1: \(contentSize)")
 			if contentSize == .zero {

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -156,7 +156,6 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			contentSize = cachedSize
 		} else {
 			contentSize = viewController.view.bounds.size
-
 			self.viewSizeCache[preferencePane.preferencePaneIdentifier] = contentSize
 		}
 

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -89,6 +89,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			immediatelyDisplayTab(index: index)
 		} else {
 			guard index != activeTab else {
+				setWindowFrame(for: preferencePanes[index].viewController)
 				return
 			}
 
@@ -112,9 +113,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	private var activeChildViewConstraints = [NSLayoutConstraint]()
 
 	private func immediatelyDisplayTab(index: Int) {
-//		let toViewController = children[index]
-		print("immediatelyDisplayTab", index)
-		let toViewController = preferencePanes[index].viewController
+		let toViewController = children[index]
 		view.addSubview(toViewController.view)
 		activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()
 		setWindowFrame(for: toViewController, animated: false)

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -195,21 +195,27 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			preconditionFailure()
 		}
 
+		print("setWindowFrame reached")
+
 		var contentSize = CGSize.zero
 		if let cachedSize = self.viewSizeCache[preferencePane.preferencePaneIdentifier] {
 			contentSize = cachedSize
+			print("cached size used: \(contentSize)")
 		} else {
 			contentSize = viewController.view.fittingSize
 			if contentSize == .zero {
 				contentSize = viewController.view.bounds.size
 			}
 			self.viewSizeCache[preferencePane.preferencePaneIdentifier] = contentSize
+			print("size added to cache: \(contentSize)")
 		}
 
 		let newWindowSize = window.frameRect(forContentRect: CGRect(origin: .zero, size: contentSize)).size
 		var frame = window.frame
 		frame.origin.y += frame.height - newWindowSize.height
 		frame.size = newWindowSize
+
+		print("new window size: \(newWindowSize)")
 
 		if isKeepingWindowCentered {
 			let horizontalDiff = (window.frame.width - newWindowSize.width) / 2

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -195,8 +195,6 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			preconditionFailure()
 		}
 
-		print("setWindowFrame reached")
-
 		var contentSize = CGSize.zero
 		if let cachedSize = self.viewSizeCache[preferencePane.preferencePaneIdentifier] {
 			contentSize = cachedSize
@@ -205,12 +203,11 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 //			viewController.view.needsUpdateConstraints = true
 			contentSize = viewController.view.fittingSize
 			print("contentSize pass 1: \(contentSize)")
-			if contentSize == .zero {
+			if contentSize.width == 0 || contentSize.height == 0 {
 				contentSize = viewController.view.bounds.size
 				print("contentSize pass 2: \(contentSize)")
 			}
 
-			print("contentSize bounds size pass: \(viewController.view.bounds.size)")
 			self.viewSizeCache[preferencePane.preferencePaneIdentifier] = contentSize
 			print("size added to cache: \(contentSize)")
 		}

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -114,7 +114,8 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	private var activeChildViewConstraints = [NSLayoutConstraint]()
 
 	private func immediatelyDisplayTab(index: Int) {
-		let toViewController = children[index]
+//		let toViewController = children[index]
+		let toViewController = preferencePanes[index].viewController
 		view.addSubview(toViewController.view)
 		activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()
 		setWindowFrame(for: toViewController, animated: false)

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -92,6 +92,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	}
 
 	func restoreInitialTab() {
+		print("Active Tab: \(activeTab)")
 		if activeTab == nil {
 			activateTab(index: 0, animated: false)
 		}

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -26,7 +26,6 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	var isAnimated: Bool = true
 
 	override func loadView() {
-		print("loadView")
 		self.view = NSView()
 		self.view.translatesAutoresizingMaskIntoConstraints = false
 	}
@@ -78,21 +77,17 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 		}
 
 		if activeTab == nil {
-			print("activeTab nil")
 			immediatelyDisplayTab(index: index)
 		} else {
 			guard index != activeTab else {
-				print("index mismatch")
 				return
 			}
 
-			print("animate transition")
 			animateTabTransition(index: index, animated: animated)
 		}
 	}
 
 	func restoreInitialTab() {
-		print("Active Tab: \(activeTab)")
 		if activeTab == nil {
 			activateTab(index: 0, animated: false)
 		}
@@ -198,20 +193,16 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 		var contentSize = CGSize.zero
 		if let cachedSize = self.viewSizeCache[preferencePane.preferencePaneIdentifier] {
 			contentSize = cachedSize
-			print("cached size used: \(contentSize)")
 		} else {
 			contentSize = viewController.view.bounds.size
 
 			self.viewSizeCache[preferencePane.preferencePaneIdentifier] = contentSize
-			print("size added to cache: \(contentSize)")
 		}
 
 		let newWindowSize = window.frameRect(forContentRect: CGRect(origin: .zero, size: contentSize)).size
 		var frame = window.frame
 		frame.origin.y += frame.height - newWindowSize.height
 		frame.size = newWindowSize
-
-		print("new window size: \(newWindowSize)")
 
 		if isKeepingWindowCentered {
 			let horizontalDiff = (window.frame.width - newWindowSize.width) / 2

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -109,8 +109,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	private var activeChildViewConstraints = [NSLayoutConstraint]()
 
 	private func immediatelyDisplayTab(index: Int) {
-//		let toViewController = children[index]
-		let toViewController = preferencePanes[index].viewController
+		let toViewController = children[index]
 		view.addSubview(toViewController.view)
 		activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()
 		setWindowFrame(for: toViewController, animated: false)

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -83,16 +83,19 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			activeTab = index
 			preferencesStyleController.selectTab(index: index)
 			updateWindowTitle(tabIndex: index)
+			setWindowFrame(for: preferencePanes[index].viewController, animated: animated)
 		}
 
 		if activeTab == nil {
+			print("activeTab nil")
 			immediatelyDisplayTab(index: index)
 		} else {
 			guard index != activeTab else {
-				setWindowFrame(for: preferencePanes[index].viewController)
+				print("index mismatch")
 				return
 			}
 
+			print("animate transition")
 			animateTabTransition(index: index, animated: animated)
 		}
 	}

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -113,6 +113,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 
 	private func immediatelyDisplayTab(index: Int) {
 //		let toViewController = children[index]
+		print("immediatelyDisplayTab", index)
 		let toViewController = preferencePanes[index].viewController
 		view.addSubview(toViewController.view)
 		activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -23,6 +23,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	var isAnimated: Bool = true
 
 	override func loadView() {
+		print("loadView")
 		self.view = NSView()
 		self.view.translatesAutoresizingMaskIntoConstraints = false
 	}

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -23,8 +23,6 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 		return view.window
 	}
 
-	var isAnimated: Bool = true
-
 	override func loadView() {
 		self.view = NSView()
 		self.view.translatesAutoresizingMaskIntoConstraints = false
@@ -124,17 +122,17 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 
 		let fromViewController = children[activeTab]
 		let toViewController = children[index]
-		let options: NSViewController.TransitionOptions = animated && isAnimated
-			? [.crossfade]
-			: []
 
 		view.removeConstraints(activeChildViewConstraints)
 
+		fromViewController.view.layer?.opacity = 0
+		toViewController.view.layer?.opacity = 0
 		transition(
 			from: fromViewController,
 			to: toViewController,
-			options: options
+			options: []
 		) {
+			toViewController.view.layer?.opacity = 1
 			self.activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()
 		}
 	}
@@ -145,40 +143,12 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 		options: NSViewController.TransitionOptions = [],
 		completionHandler completion: (() -> Void)? = nil
 	) {
-		let isAnimated = options
-			.intersection([
-				.crossfade,
-				.slideUp,
-				.slideDown,
-				.slideForward,
-				.slideBackward,
-				.slideLeft,
-				.slideRight
-			])
-			.isEmpty == false
-
-		if isAnimated {
-			NSAnimationContext.runAnimationGroup({ context in
-				context.allowsImplicitAnimation = true
-				context.duration = 0.25
-				context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-				setWindowFrame(for: toViewController, animated: true)
-
-				super.transition(
-					from: fromViewController,
-					to: toViewController,
-					options: options,
-					completionHandler: completion
-				)
-			}, completionHandler: nil)
-		} else {
-			super.transition(
-				from: fromViewController,
-				to: toViewController,
-				options: options,
-				completionHandler: completion
-			)
-		}
+		super.transition(
+			from: fromViewController,
+			to: toViewController,
+			options: [],
+			completionHandler: completion
+		)
 	}
 
 	private func setWindowFrame(for viewController: NSViewController, animated: Bool = false) {

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -117,14 +117,11 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 
 		view.removeConstraints(activeChildViewConstraints)
 
-		fromViewController.view.layer?.opacity = 0
-		toViewController.view.layer?.opacity = 0
 		transition(
 			from: fromViewController,
 			to: toViewController,
 			options: []
 		) {
-			toViewController.view.layer?.opacity = 1
 			self.activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()
 		}
 	}
@@ -135,12 +132,30 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 		options: NSViewController.TransitionOptions = [],
 		completionHandler completion: (() -> Void)? = nil
 	) {
+		// Ensure views have layers
+		fromViewController.view.wantsLayer = true
+		toViewController.view.wantsLayer = true
+
+		// Make views invisible before animation starts
+		fromViewController.view.layer?.opacity = 0
+		toViewController.view.layer?.opacity = 0
+
+		// Start window frame animation
+		setWindowFrame(for: toViewController, animated: true)
+
+		// Do the VC transition
 		super.transition(
 			from: fromViewController,
 			to: toViewController,
-			options: [],
+			options: options,
 			completionHandler: completion
 		)
+
+		// Make destination VC visible after animation has ended
+		// Assuming of course that macOS's animation takes 250ms to run
+		DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+			toViewController.view.layer?.opacity = 1
+		}
 	}
 
 	private func setWindowFrame(for viewController: NSViewController, animated: Bool = false) {

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -200,13 +200,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			contentSize = cachedSize
 			print("cached size used: \(contentSize)")
 		} else {
-//			viewController.view.needsUpdateConstraints = true
-			contentSize = viewController.view.fittingSize
-			print("contentSize pass 1: \(contentSize)")
-			if contentSize.width == 0 || contentSize.height == 0 {
-				contentSize = viewController.view.bounds.size
-				print("contentSize pass 2: \(contentSize)")
-			}
+			contentSize = viewController.view.bounds.size
 
 			self.viewSizeCache[preferencePane.preferencePaneIdentifier] = contentSize
 			print("size added to cache: \(contentSize)")

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -112,7 +112,8 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	private var activeChildViewConstraints = [NSLayoutConstraint]()
 
 	private func immediatelyDisplayTab(index: Int) {
-		let toViewController = children[index]
+//		let toViewController = children[index]
+		let toViewController = preferencePanes[index].viewController
 		view.addSubview(toViewController.view)
 		activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()
 		setWindowFrame(for: toViewController, animated: false)

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -203,9 +203,13 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 			print("cached size used: \(contentSize)")
 		} else {
 			contentSize = viewController.view.fittingSize
+			print("contentSize pass 1: \(contentSize)")
 			if contentSize == .zero {
 				contentSize = viewController.view.bounds.size
+				print("contentSize pass 2: \(contentSize)")
 			}
+
+			print("contentSize intrinsic size pass: \(viewController.view.intrinsicContentSize)")
 			self.viewSizeCache[preferencePane.preferencePaneIdentifier] = contentSize
 			print("size added to cache: \(contentSize)")
 		}

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -17,7 +17,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 		return preferencesStyleController?.toolbarItemIdentifiers() ?? []
 	}
 
-	private var viewSizeCache: [PreferencePaneIdentifier: NSSize] = [:]
+	private var viewSizeCache = [PreferencePaneIdentifier: CGSize]()
 
 	var window: NSWindow! {
 		return view.window
@@ -188,13 +188,14 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	}
 
 	private func setWindowFrame(for viewController: NSViewController, animated: Bool = false) {
-		guard let window = window,
-			  let preferencePane = preferencePanes.first(where: { $0.viewController == viewController })
-			else {
+		guard
+			let window = window,
+			let preferencePane = preferencePanes.first(where: { $0.viewController == viewController })
+		else {
 			preconditionFailure()
 		}
 
-		var contentSize = NSSize.zero
+		var contentSize = CGSize.zero
 		if let cachedSize = self.viewSizeCache[preferencePane.preferencePaneIdentifier] {
 			contentSize = cachedSize
 		} else {

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -3,15 +3,6 @@ import Cocoa
 public final class PreferencesWindowController: NSWindowController {
 	private let tabViewController = PreferencesTabViewController()
 
-	public var isAnimated: Bool {
-		get {
-			return tabViewController.isAnimated
-		}
-		set {
-			tabViewController.isAnimated = newValue
-		}
-	}
-
 	public var hidesToolbarForSingleItem: Bool {
 		didSet {
 			updateToolbarVisibility()
@@ -52,7 +43,6 @@ public final class PreferencesWindowController: NSWindowController {
 				return (preferencePanes.count <= 1) ? .visible : .hidden
 			}
 		}()
-		tabViewController.isAnimated = animated
 		tabViewController.configure(preferencePanes: preferencePanes, style: style)
 		updateToolbarVisibility()
 	}


### PR DESCRIPTION
This is an attempt to fix #9, specifically the part where the preference window doesn't show up.

I tried to fix this by using `viewController.view.bounds.size` in cases where `viewController.view.fittingSize` is `.zero` and caching the resulting value. 
Without the cache, both `bounds.size` and `fittingSize` become `.zero` later on, which would cause problems.