### PR TITLE
Add a "Used in these app" section to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,7 +222,7 @@ You might also like Sindre's [apps](https://sindresorhus.com/apps).
 - [The Archive](https://zettelkasten.de/the-archive/)
 - [Word Counter](https://wordcounterapp.com/)
 
-Want to tell the world about your app using Preferences? Open a PR!
+Want to tell the world about your app that is using Preferences? Open a PR!
 
 
 ## Maintainers

--- a/readme.md
+++ b/readme.md
@@ -216,7 +216,7 @@ The `PreferencesWindowController` adheres to the [Apple HIG](https://developer.a
 You might also like Sindre's [apps](https://sindresorhus.com/apps).
 
 
-### Used in these app
+## Used in these apps
 
 - [TableFlip](https://tableflipapp.com/)
 - [The Archive](https://zettelkasten.de/the-archive/)

--- a/readme.md
+++ b/readme.md
@@ -218,9 +218,9 @@ You might also like Sindre's [apps](https://sindresorhus.com/apps).
 
 ## Used in these apps
 
-- [TableFlip](https://tableflipapp.com/)
-- [The Archive](https://zettelkasten.de/the-archive/)
-- [Word Counter](https://wordcounterapp.com/)
+- [TableFlip](https://tableflipapp.com/), visual Markdown table editor by [Christian Tietze](https://github.com/DivineDominion)
+- [The Archive](https://zettelkasten.de/the-archive/), note-taking application by [Christian Tietze](https://github.com/DivineDominion)
+- [Word Counter](https://wordcounterapp.com/), measuring writer's productivity by [Christian Tietze](https://github.com/DivineDominion)
 
 Want to tell the world about your app that is using Preferences? Open a PR!
 

--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,15 @@ The `PreferencesWindowController` adheres to the [Apple HIG](https://developer.a
 You might also like Sindre's [apps](https://sindresorhus.com/apps).
 
 
+### Used in these app
+
+- [TableFlip](https://tableflipapp.com/)
+- [The Archive](https://zettelkasten.de/the-archive/)
+- [Word Counter](https://wordcounterapp.com/)
+
+Want to tell the world about your app using Preferences? Open a PR!
+
+
 ## Maintainers
 
 - [Sindre Sorhus](https://github.com/sindresorhus)

--- a/readme.md
+++ b/readme.md
@@ -218,9 +218,9 @@ You might also like Sindre's [apps](https://sindresorhus.com/apps).
 
 ## Used in these apps
 
-- [TableFlip](https://tableflipapp.com/), visual Markdown table editor by [Christian Tietze](https://github.com/DivineDominion)
-- [The Archive](https://zettelkasten.de/the-archive/), note-taking application by [Christian Tietze](https://github.com/DivineDominion)
-- [Word Counter](https://wordcounterapp.com/), measuring writer's productivity by [Christian Tietze](https://github.com/DivineDominion)
+- [TableFlip](https://tableflipapp.com) - Visual Markdown table editor by [Christian Tietze](https://github.com/DivineDominion)
+- [The Archive](https://zettelkasten.de/the-archive/) - Note-taking app by [Christian Tietze](https://github.com/DivineDominion)
+- [Word Counter](https://wordcounterapp.com) - Measuring writer's productivity by [Christian Tietze](https://github.com/DivineDominion)
 
 Want to tell the world about your app that is using Preferences? Open a PR!
 


### PR DESCRIPTION
I started bare-bones:

```md
- [TableFlip](https://tableflipapp.com/)
- [The Archive](https://zettelkasten.de/the-archive/)
- [Word Counter](https://wordcounterapp.com/)
```

How much detail do you think is interesting before it turns into an advert? 

With short description:

```md
- [TableFlip](https://tableflipapp.com/), visual Markdown table editor
- [The Archive](https://zettelkasten.de/the-archive/), note-taking application
- [Word Counter](https://wordcounterapp.com/), measuring writer's productivity
```

I would think that e.g. this would be too much:

```md
- [The Archive](https://zettelkasten.de/the-archive/), lightning-fast app to manage your knowledge and write more
```

Additionally, what about author attributions?

```md
- [TableFlip](https://tableflipapp.com/), visual Markdown table editor by [Christian Tietze][...]
- [The Archive](https://zettelkasten.de/the-archive/), note-taking application by [Christian Tietze][...]
- [Word Counter](https://wordcounterapp.com/), measuring writer's productivity by [Christian Tietze][...]
```

Which links are desirable before it, again, turns into an advert of sorts?

- requiring a link to the GitHub profile: emphasizes the open source author aspect
- allowing links to personal websites: direct traffic as a marketing tool
- allowing links to Twitter/social media

What do you think @sindresorhus?