### PR TITLE
Fix window-restoration (PR #27)

### DIFF
--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -82,11 +82,6 @@ public final class PreferencesWindowController: NSWindowController {
 	/// - Parameter preferencePane: Identifier of the preference pane to display, or `nil` to show the
 	///   tab that was open when the user last closed the window.
 	public func show(preferencePane preferenceIdentifier: PreferencePane.Identifier? = nil) {
-		if !window!.isVisible {
-			window?.center()
-		}
-
-		showWindow(self)
 		if let preferenceIdentifier = preferenceIdentifier {
 			tabViewController.activateTab(preferenceIdentifier: preferenceIdentifier, animated: false)
 		} else {

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -96,12 +96,9 @@ public final class PreferencesWindowController: NSWindowController {
 	}
 
 	private func restoreWindowPosition() {
-		guard
-			let window = self.window,
-			let screenContainingWindow = window.screen
-		else {
-			return
-		}
+		guard let window = self.window,
+			let screenContainingWindow = window.screen 
+			else { return }
 
 		let x = screenContainingWindow.visibleFrame.midX - window.frame.width / 2
 		let y = screenContainingWindow.visibleFrame.midY - window.frame.height / 2

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -1,5 +1,9 @@
 import Cocoa
 
+extension NSWindow.FrameAutosaveName {
+	static let preferences: NSWindow.FrameAutosaveName = "com.sindresorhus.Preferences.FrameAutosaveName-WIP-1"
+}
+
 public final class PreferencesWindowController: NSWindowController {
 	private let tabViewController = PreferencesTabViewController()
 
@@ -28,7 +32,7 @@ public final class PreferencesWindowController: NSWindowController {
 		style: PreferencesStyle = .toolbarItems,
 		animated: Bool = true,
 		hidesToolbarForSingleItem: Bool = true
-	) {
+		) {
 		precondition(!preferencePanes.isEmpty, "You need to set at least one view controller")
 
 		let window = UserInteractionPausableWindow(
@@ -78,16 +82,32 @@ public final class PreferencesWindowController: NSWindowController {
 	/// - Parameter preferencePane: Identifier of the preference pane to display, or `nil` to show the
 	///   tab that was open when the user last closed the window.
 	public func show(preferencePane preferenceIdentifier: PreferencePaneIdentifier? = nil) {
-		if !window!.isVisible {
-			window?.center()
-		}
-
-		showWindow(self)
 		if let preferenceIdentifier = preferenceIdentifier {
 			tabViewController.activateTab(preferenceIdentifier: preferenceIdentifier, animated: false)
 		} else {
 			tabViewController.restoreInitialTab()
 		}
+
+		showWindow(self)
+
+		centerWindowOnFirstStart()
+
 		NSApp.activate(ignoringOtherApps: true)
+	}
+
+	private func centerWindowOnFirstStart() {
+		guard let window = self.window,
+			let screenContainingWindow = window.screen else {
+				return
+		}
+
+		// When setting the autosave name, the current position isn't stored immediately.
+		// Trying to read the frame values will fail, so we can center it.
+		window.setFrameAutosaveName(.preferences)
+		if window.setFrameUsingName(.preferences) == false {
+			let xPos = screenContainingWindow.frame.midX - window.frame.width / 2
+			let yPos = screenContainingWindow.frame.midY - window.frame.height / 2
+			window.setFrameOrigin(NSPoint(x: xPos, y: yPos))
+		}
 	}
 }

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -90,12 +90,12 @@ public final class PreferencesWindowController: NSWindowController {
 
 		showWindow(self)
 
-		centerWindowOnFirstStart()
+		restoreWindowPosition()
 
 		NSApp.activate(ignoringOtherApps: true)
 	}
 
-	private func centerWindowOnFirstStart() {
+	private func restoreWindowPosition() {
 		guard
 			let window = self.window,
 			let screenContainingWindow = window.screen

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -108,14 +108,10 @@ public final class PreferencesWindowController: NSWindowController {
 			return
 		}
 
-		// When setting the autosave name, the current position isn't stored immediately.
-		// Trying to read the frame values will fail, so we can center it.
+		let x = screenContainingWindow.visibleFrame.midX - window.frame.width / 2
+		let y = screenContainingWindow.visibleFrame.midY - window.frame.height / 2
+		window.setFrameOrigin(CGPoint(x: x, y: y))
+		window.setFrameUsingName(.preferences)
 		window.setFrameAutosaveName(.preferences)
-
-		if window.setFrameUsingName(.preferences) == false {
-			let x = screenContainingWindow.frame.midX - window.frame.width / 2
-			let y = screenContainingWindow.frame.midY - window.frame.height / 2
-			window.setFrameOrigin(CGPoint(x: x, y: y))
-		}
 	}
 }

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -1,7 +1,7 @@
 import Cocoa
 
 extension NSWindow.FrameAutosaveName {
-	static let preferences: NSWindow.FrameAutosaveName = "com.sindresorhus.Preferences.FrameAutosaveName-WIP-1"
+	static let preferences: NSWindow.FrameAutosaveName = "com.sindresorhus.Preferences.FrameAutosaveName"
 }
 
 public final class PreferencesWindowController: NSWindowController {

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -32,7 +32,7 @@ public final class PreferencesWindowController: NSWindowController {
 		style: PreferencesStyle = .toolbarItems,
 		animated: Bool = true,
 		hidesToolbarForSingleItem: Bool = true
-		) {
+	) {
 		precondition(!preferencePanes.isEmpty, "You need to set at least one view controller")
 
 		let window = UserInteractionPausableWindow(
@@ -101,18 +101,21 @@ public final class PreferencesWindowController: NSWindowController {
 	}
 
 	private func centerWindowOnFirstStart() {
-		guard let window = self.window,
-			let screenContainingWindow = window.screen else {
-				return
+		guard
+			let window = self.window,
+			let screenContainingWindow = window.screen
+		else {
+			return
 		}
 
 		// When setting the autosave name, the current position isn't stored immediately.
 		// Trying to read the frame values will fail, so we can center it.
 		window.setFrameAutosaveName(.preferences)
+
 		if window.setFrameUsingName(.preferences) == false {
-			let xPos = screenContainingWindow.frame.midX - window.frame.width / 2
-			let yPos = screenContainingWindow.frame.midY - window.frame.height / 2
-			window.setFrameOrigin(NSPoint(x: xPos, y: yPos))
+			let x = screenContainingWindow.frame.midX - window.frame.width / 2
+			let y = screenContainingWindow.frame.midY - window.frame.height / 2
+			window.setFrameOrigin(CGPoint(x: x, y: y))
 		}
 	}
 }


### PR DESCRIPTION
I have modified @DivineDominion's code a bit to get centering and restoring the preferences window to work.

1. Call `showWindow()`.
2. Get the screen the window is located on and calculates the new coordinates.

`window.center()` does not work. I don't know why.