### PR TITLE
Namespace the preference pane identifier

### DIFF
--- a/Example/AdvancedPreferenceViewController.swift
+++ b/Example/AdvancedPreferenceViewController.swift
@@ -2,7 +2,7 @@ import Cocoa
 import Preferences
 
 final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
-	let preferencePaneIdentifier = PreferencePaneIdentifier.advanced
+	let preferencePaneIdentifier = PreferencePane.Identifier.advanced
 	let preferencePaneTitle = "Advanced"
 	let toolbarItemIcon = NSImage(named: NSImage.advancedName)!
 

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -1,9 +1,9 @@
 import Cocoa
 import Preferences
 
-extension PreferencePaneIdentifier {
-	static let general = PreferencePaneIdentifier("general")
-	static let advanced = PreferencePaneIdentifier("advanced")
+extension PreferencePane.Identifier {
+	static let general = Identifier("general")
+	static let advanced = Identifier("advanced")
 }
 
 @NSApplicationMain

--- a/Example/GeneralPreferenceViewController.swift
+++ b/Example/GeneralPreferenceViewController.swift
@@ -2,7 +2,7 @@ import Cocoa
 import Preferences
 
 final class GeneralPreferenceViewController: NSViewController, PreferencePane {
-	let preferencePaneIdentifier = PreferencePaneIdentifier.general
+	let preferencePaneIdentifier = PreferencePane.Identifier.general
 	let preferencePaneTitle = "General"
 	let toolbarItemIcon = NSImage(named: NSImage.preferencesGeneralName)!
 

--- a/Sources/Preferences/PreferencePane.swift
+++ b/Sources/Preferences/PreferencePane.swift
@@ -1,6 +1,8 @@
 import Cocoa
 
 public struct PreferencePaneIdentifier: Equatable, RawRepresentable {
+	public typealias Identifier = PreferencePaneIdentifier
+
 	public let rawValue: String
 
 	public init(rawValue: String) {
@@ -9,7 +11,9 @@ public struct PreferencePaneIdentifier: Equatable, RawRepresentable {
 }
 
 public protocol PreferencePane: AnyObject {
-	var preferencePaneIdentifier: PreferencePaneIdentifier { get }
+	typealias Identifier = PreferencePaneIdentifier
+
+	var preferencePaneIdentifier: Identifier { get }
 	var preferencePaneTitle: String { get }
 	var toolbarItemIcon: NSImage { get }
 	var viewController: NSViewController { get }
@@ -31,7 +35,7 @@ extension PreferencePane {
 	}
 }
 
-extension PreferencePaneIdentifier {
+extension PreferencePane.Identifier {
 	public init(_ rawValue: String) {
 		self.init(rawValue: rawValue)
 	}

--- a/Sources/Preferences/PreferencesStyleController.swift
+++ b/Sources/Preferences/PreferencesStyleController.swift
@@ -5,12 +5,12 @@ protocol PreferencesStyleController: AnyObject {
 	var isKeepingWindowCentered: Bool { get }
 
 	func toolbarItemIdentifiers() -> [NSToolbarItem.Identifier]
-	func toolbarItem(preferenceIdentifier: PreferencePaneIdentifier) -> NSToolbarItem?
+	func toolbarItem(preferenceIdentifier: PreferencePane.Identifier) -> NSToolbarItem?
 
 	func selectTab(index: Int)
 }
 
 protocol PreferencesStyleControllerDelegate: AnyObject {
-	func activateTab(preferenceIdentifier: PreferencePaneIdentifier, animated: Bool)
+	func activateTab(preferenceIdentifier: PreferencePane.Identifier, animated: Bool)
 	func activateTab(index: Int, animated: Bool)
 }

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -58,7 +58,7 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 		activateTab(preferenceIdentifier: preferencePane.preferencePaneIdentifier, animated: animated)
 	}
 
-	func activateTab(preferenceIdentifier: PreferencePaneIdentifier, animated: Bool) {
+	func activateTab(preferenceIdentifier: PreferencePane.Identifier, animated: Bool) {
 		guard let index = (preferencePanes.firstIndex { $0.preferencePaneIdentifier == preferenceIdentifier }) else {
 			return activateTab(index: 0, animated: animated)
 		}
@@ -222,6 +222,6 @@ extension PreferencesTabViewController: NSToolbarDelegate {
 			return nil
 		}
 
-		return preferencesStyleController.toolbarItem(preferenceIdentifier: PreferencePaneIdentifier(fromToolbarItemIdentifier: itemIdentifier))
+		return preferencesStyleController.toolbarItem(preferenceIdentifier: PreferencePane.Identifier(fromToolbarItemIdentifier: itemIdentifier))
 	}
 }

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -70,14 +70,14 @@ public final class PreferencesWindowController: NSWindowController {
 
 	/// Show the preferences window and brings it to front.
 	///
-	/// If you pass a `PreferencePaneIdentifier`, the window will activate the corresponding tab.
+	/// If you pass a `PreferencePane.Identifier`, the window will activate the corresponding tab.
 	///
 	/// - See `close()` to close the window again.
 	/// - See `showWindow(_:)` to show the window without the convenience of activating the app.
 	/// - Note: Unless you need to open a specific pane, prefer not to pass a parameter at all or `nil`.
 	/// - Parameter preferencePane: Identifier of the preference pane to display, or `nil` to show the
 	///   tab that was open when the user last closed the window.
-	public func show(preferencePane preferenceIdentifier: PreferencePaneIdentifier? = nil) {
+	public func show(preferencePane preferenceIdentifier: PreferencePane.Identifier? = nil) {
 		if !window!.isVisible {
 			window?.center()
 		}

--- a/Sources/Preferences/SegmentedControlStyleViewController.swift
+++ b/Sources/Preferences/SegmentedControlStyleViewController.swift
@@ -113,7 +113,7 @@ final class SegmentedControlStyleViewController: NSViewController, PreferencesSt
 		]
 	}
 
-	func toolbarItem(preferenceIdentifier: PreferencePaneIdentifier) -> NSToolbarItem? {
+	func toolbarItem(preferenceIdentifier: PreferencePane.Identifier) -> NSToolbarItem? {
 		let toolbarItemIdentifier = preferenceIdentifier.toolbarItemIdentifier
 		precondition(toolbarItemIdentifier == .toolbarSegmentedControlItem)
 

--- a/Sources/Preferences/ToolbarItemStyleViewController.swift
+++ b/Sources/Preferences/ToolbarItemStyleViewController.swift
@@ -35,7 +35,7 @@ final class ToolbarItemStyleViewController: NSObject, PreferencesStyleController
 		return toolbarItemIdentifiers
 	}
 
-	func toolbarItem(preferenceIdentifier: PreferencePaneIdentifier) -> NSToolbarItem? {
+	func toolbarItem(preferenceIdentifier: PreferencePane.Identifier) -> NSToolbarItem? {
 		guard let preference = (preferencePanes.first { $0.preferencePaneIdentifier == preferenceIdentifier }) else {
 			preconditionFailure()
 		}
@@ -50,7 +50,7 @@ final class ToolbarItemStyleViewController: NSObject, PreferencesStyleController
 
 	@IBAction private func toolbarItemSelected(_ toolbarItem: NSToolbarItem) {
 		delegate?.activateTab(
-			preferenceIdentifier: PreferencePaneIdentifier(fromToolbarItemIdentifier: toolbarItem.itemIdentifier),
+			preferenceIdentifier: PreferencePane.Identifier(fromToolbarItemIdentifier: toolbarItem.itemIdentifier),
 			animated: true
 		)
 	}

--- a/readme.md
+++ b/readme.md
@@ -48,9 +48,9 @@ First, create a collection of preference pane identifiers:
 ```swift
 import Preferences
 
-extension PreferencePaneIdentifier {
-	static let general = PreferencePaneIdentifier("general")
-	static let advanced = PreferencePaneIdentifier("advanced")
+extension PreferencePane.Identifier {
+	static let general = Identifier("general")
+	static let advanced = Identifier("advanced")
 }
 ```
 
@@ -63,7 +63,7 @@ import Cocoa
 import Preferences
 
 final class GeneralPreferenceViewController: NSViewController, PreferencePane {
-	let preferencePaneIdentifier = PreferencePaneIdentifier.general
+	let preferencePaneIdentifier = PreferencePane.Identifier.general
 	let preferencePaneTitle = "General"
 	let toolbarItemIcon = NSImage(named: NSImage.preferencesGeneralName)!
 
@@ -86,7 +86,7 @@ import Cocoa
 import Preferences
 
 final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
-	let preferencePaneIdentifier = PreferencePaneIdentifier.advanced
+	let preferencePaneIdentifier = PreferencePane.Identifier.advanced
 	let preferencePaneTitle = "Advanced"
 	let toolbarItemIcon = NSImage(named: NSImage.advancedName)!
 
@@ -159,7 +159,7 @@ lazy var preferencesWindowController = PreferencesWindowController(
 
 ```swift
 public protocol PreferencePane: AnyObject {
-	var preferencePaneIdentifier: PreferencePaneIdentifier { get }
+	var preferencePaneIdentifier: PreferencePane.Identifier { get }
 	var preferencePaneTitle: String { get }
 	var toolbarItemIcon: NSImage { get } // Not required when using the .`segmentedControl` style
 }
@@ -177,7 +177,7 @@ public final class PreferencesWindowController: NSWindowController {
 		hidesToolbarForSingleItem: Bool = true
 	)
 
-	func show(preferencePane: PreferencePaneIdentifier? = nil)
+	func show(preferencePane: PreferencePane.Identifier? = nil)
 }
 ```
 


### PR DESCRIPTION
Protocols cannot have a tested types, which is why we currently have `PreferencePaneIdentifier`, but I just realized we can use `typealias` to achieve `PreferencesPane.Identifier`. As a bonus it's now shorter to define the identifiers too.

// @DivineDominion 