### PR TITLE
Forward responder chain actions to the selected pane

### DIFF
--- a/Example/AdvancedPreferenceViewController.swift
+++ b/Example/AdvancedPreferenceViewController.swift
@@ -7,7 +7,7 @@ final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
 	let toolbarItemIcon = NSImage(systemSymbolName: "gearshape.2", accessibilityDescription: "Advanced preferences")!
 
 	@IBOutlet private var fontLabel: NSTextField!
-	private var font: NSFont = .systemFont(ofSize: 14.0)
+	private var font = NSFont.systemFont(ofSize: 14)
 
 	override var nibName: NSNib.Name? { "AdvancedPreferenceViewController" }
 

--- a/Example/AdvancedPreferenceViewController.swift
+++ b/Example/AdvancedPreferenceViewController.swift
@@ -6,12 +6,15 @@ final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
 	let preferencePaneTitle = "Advanced"
 	let toolbarItemIcon = NSImage(systemSymbolName: "gearshape.2", accessibilityDescription: "Advanced preferences")!
 
+	@IBOutlet private var fontLabel: NSTextField!
+	private var font: NSFont = .systemFont(ofSize: 14.0)
+
 	override var nibName: NSNib.Name? { "AdvancedPreferenceViewController" }
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
-		// Setup stuff here
+		updateFontLabel()
 	}
 
 	@IBAction
@@ -19,11 +22,18 @@ final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
 
 	@IBAction
 	private func showFontPanel(_ sender: Any) {
-		NSFontManager.shared.orderFrontFontPanel(self)
+		let fontManager = NSFontManager.shared
+		fontManager.setSelectedFont(font, isMultiple: false)
+		fontManager.orderFrontFontPanel(self)
 	}
 
 	@IBAction
-	private func changeFont(_ sender: Any) {
-		print(sender)
+	private func changeFont(_ sender: NSFontManager) {
+		font = sender.convert(font)
+		updateFontLabel()
+	}
+
+	private func updateFontLabel() {
+		fontLabel.stringValue = font.displayName ?? font.fontName
 	}
 }

--- a/Example/AdvancedPreferenceViewController.swift
+++ b/Example/AdvancedPreferenceViewController.swift
@@ -19,8 +19,7 @@ final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
 
 	@IBAction
 	private func showFontPanel(_ sender: Any) {
-		let fontManager = NSFontManager.shared
-		fontManager.orderFrontFontPanel(self)
+		NSFontManager.shared.orderFrontFontPanel(self)
 	}
 
 	@IBAction

--- a/Example/AdvancedPreferenceViewController.swift
+++ b/Example/AdvancedPreferenceViewController.swift
@@ -16,4 +16,15 @@ final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
 
 	@IBAction
 	private func zoomAction(_ sender: Any) {} // swiftlint:disable:this attributes
+
+	@IBAction
+	private func showFontPanel(_ sender: Any) {
+		let fontManager = NSFontManager.shared
+		fontManager.orderFrontFontPanel(self)
+	}
+
+	@IBAction
+	private func changeFont(_ sender: Any) {
+		print(sender)
+	}
 }

--- a/Example/AdvancedPreferenceViewController.xib
+++ b/Example/AdvancedPreferenceViewController.xib
@@ -7,6 +7,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="AdvancedPreferenceViewController" customModule="PreferencesExample" customModuleProvider="target">
             <connections>
+                <outlet property="fontLabel" destination="8LP-g5-bnE" id="js7-9U-Oo3"/>
                 <outlet property="view" destination="c22-O7-iKe" id="buC-Sz-vlD"/>
             </connections>
         </customObject>
@@ -35,7 +36,7 @@
                     </columns>
                     <gridCells>
                         <gridCell row="ltX-Ja-eM6" column="RqK-yY-jzI" id="042-ss-ffF">
-                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PfT-L0-R1r">
+                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PfT-L0-R1r">
                                 <rect key="frame" x="90" y="175" width="43" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Zoom:" id="bnu-AS-zpg">
                                     <font key="font" usesAppearanceFont="YES"/>
@@ -45,7 +46,7 @@
                             </textField>
                         </gridCell>
                         <gridCell row="ltX-Ja-eM6" column="d5q-Pb-pgU" id="W2c-el-Egx">
-                            <button key="contentView" horizontalHuggingPriority="248" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zhk-nP-ekf">
+                            <button key="contentView" horizontalHuggingPriority="248" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zhk-nP-ekf">
                                 <rect key="frame" x="139" y="174" width="311" height="18"/>
                                 <buttonCell key="cell" type="radio" title="Animate zoom" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="G15-Qe-p8C">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -58,7 +59,7 @@
                         </gridCell>
                         <gridCell row="OOd-hD-rve" column="RqK-yY-jzI" id="ibh-ig-esN"/>
                         <gridCell row="OOd-hD-rve" column="d5q-Pb-pgU" id="1P6-Pp-b5f">
-                            <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zL0-h8-cNf">
+                            <button key="contentView" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zL0-h8-cNf">
                                 <rect key="frame" x="139" y="150" width="153" height="18"/>
                                 <buttonCell key="cell" type="radio" title="Zoom in on selection" bezelStyle="regularSquare" imagePosition="left" inset="2" id="1V0-bu-KPz">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -70,14 +71,14 @@
                             </button>
                         </gridCell>
                         <gridCell row="If4-3e-uiP" column="RqK-yY-jzI" headOfMergedCell="iwB-6h-jgI" id="iwB-6h-jgI">
-                            <box key="contentView" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KsN-qr-GRh">
-                                <rect key="frame" x="0.0" y="113" width="450" height="5"/>
+                            <box key="contentView" verticalHuggingPriority="750" ambiguous="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KsN-qr-GRh">
+                                <rect key="frame" x="0.0" y="123" width="450" height="5"/>
                             </box>
                         </gridCell>
                         <gridCell row="If4-3e-uiP" column="d5q-Pb-pgU" headOfMergedCell="iwB-6h-jgI" id="UcV-H8-fjJ"/>
                         <gridCell row="R2Q-rY-cRM" column="RqK-yY-jzI" id="h2k-EF-30A">
-                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Pwh-HF-wf6">
-                                <rect key="frame" x="-1" y="74" width="134" height="16"/>
+                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Pwh-HF-wf6">
+                                <rect key="frame" x="-1" y="84" width="134" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Default shape colour:" id="UWB-wJ-kV4">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -86,8 +87,8 @@
                             </textField>
                         </gridCell>
                         <gridCell row="R2Q-rY-cRM" column="d5q-Pb-pgU" id="Xm6-Te-Jzh">
-                            <colorWell key="contentView" translatesAutoresizingMaskIntoConstraints="NO" id="2HU-om-C7T">
-                                <rect key="frame" x="141" y="67" width="75" height="30"/>
+                            <colorWell key="contentView" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2HU-om-C7T">
+                                <rect key="frame" x="141" y="77" width="75" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="SSi-8a-8qj"/>
                                     <constraint firstAttribute="width" constant="75" id="US5-Mf-wy6"/>
@@ -96,8 +97,8 @@
                             </colorWell>
                         </gridCell>
                         <gridCell row="ZnY-h9-dEu" column="RqK-yY-jzI" id="dHH-pO-G3q">
-                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kdZ-Ix-AIT">
-                                <rect key="frame" x="73" y="31" width="60" height="16"/>
+                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kdZ-Ix-AIT">
+                                <rect key="frame" x="73" y="41" width="60" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Nudging:" id="UN1-r8-SEh">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -106,8 +107,8 @@
                             </textField>
                         </gridCell>
                         <gridCell row="ZnY-h9-dEu" column="d5q-Pb-pgU" id="7vR-7C-BgA">
-                            <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="dW1-gQ-chh">
-                                <rect key="frame" x="141" y="28" width="100" height="21"/>
+                            <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dW1-gQ-chh">
+                                <rect key="frame" x="141" y="38" width="100" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="rij-vW-UEb"/>
                                 </constraints>
@@ -119,8 +120,8 @@
                             </textField>
                         </gridCell>
                         <gridCell row="IHy-gl-Vqw" column="RqK-yY-jzI" id="p3c-Ej-XuJ">
-                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DFm-5v-ZoC">
-                                <rect key="frame" x="98" y="2" width="35" height="16"/>
+                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DFm-5v-ZoC">
+                                <rect key="frame" x="98" y="7" width="35" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Font:" id="a8Q-Mw-3Xn">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -129,19 +130,21 @@
                             </textField>
                         </gridCell>
                         <gridCell row="IHy-gl-Vqw" column="d5q-Pb-pgU" id="y99-sH-fhR">
-                            <stackView key="contentView" distribution="fill" orientation="horizontal" alignment="centerY" spacing="64" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="irX-8V-EUR">
-                                <rect key="frame" x="141" y="0.0" width="228" height="20"/>
-                                <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8LP-g5-bnE">
-                                        <rect key="frame" x="-2" y="2" width="90" height="16"/>
+                            <stackView key="contentView" orientation="horizontal" alignment="centerY" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" ambiguous="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="irX-8V-EUR">
+                                <rect key="frame" x="141" y="0.0" width="275" height="30"/>
+                                <beginningViews>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8LP-g5-bnE">
+                                        <rect key="frame" x="-2" y="7" width="90" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="SF Mono, 14.0" id="UeQ-YK-DOh">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eZz-lW-sdX">
-                                        <rect key="frame" x="143" y="-7" width="92" height="32"/>
+                                </beginningViews>
+                                <endViews>
+                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eZz-lW-sdX">
+                                        <rect key="frame" x="190" y="-2" width="92" height="32"/>
                                         <buttonCell key="cell" type="push" title="Change..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="9nr-gt-gdZ">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -150,7 +153,10 @@
                                             <action selector="showFontPanel:" target="-2" id="b0A-hx-eca"/>
                                         </connections>
                                     </button>
-                                </subviews>
+                                </endViews>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="275" id="vZ6-7I-Bcg"/>
+                                </constraints>
                                 <visibilityPriorities>
                                     <integer value="1000"/>
                                     <integer value="1000"/>

--- a/Example/AdvancedPreferenceViewController.xib
+++ b/Example/AdvancedPreferenceViewController.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,10 +13,10 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="510" height="205"/>
+            <rect key="frame" x="0.0" y="0.0" width="510" height="231"/>
             <subviews>
                 <gridView xPlacement="center" yPlacement="center" rowAlignment="none" rowSpacing="8" columnSpacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="UrC-xJ-uLm">
-                    <rect key="frame" x="30" y="20" width="450" height="165"/>
+                    <rect key="frame" x="30" y="20" width="450" height="191"/>
                     <constraints>
                         <constraint firstItem="KsN-qr-GRh" firstAttribute="leading" secondItem="UrC-xJ-uLm" secondAttribute="leading" id="utm-J4-Yzj"/>
                         <constraint firstAttribute="width" constant="450" id="vG6-yf-hye"/>
@@ -28,6 +27,7 @@
                         <gridRow yPlacement="center" height="20" id="If4-3e-uiP"/>
                         <gridRow bottomPadding="10" id="R2Q-rY-cRM"/>
                         <gridRow id="ZnY-h9-dEu"/>
+                        <gridRow id="IHy-gl-Vqw"/>
                     </rows>
                     <columns>
                         <gridColumn xPlacement="trailing" width="131" id="RqK-yY-jzI"/>
@@ -36,7 +36,7 @@
                     <gridCells>
                         <gridCell row="ltX-Ja-eM6" column="RqK-yY-jzI" id="042-ss-ffF">
                             <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PfT-L0-R1r">
-                                <rect key="frame" x="90" y="149" width="43" height="16"/>
+                                <rect key="frame" x="90" y="175" width="43" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Zoom:" id="bnu-AS-zpg">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -46,7 +46,7 @@
                         </gridCell>
                         <gridCell row="ltX-Ja-eM6" column="d5q-Pb-pgU" id="W2c-el-Egx">
                             <button key="contentView" horizontalHuggingPriority="248" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zhk-nP-ekf">
-                                <rect key="frame" x="140" y="148" width="312" height="18"/>
+                                <rect key="frame" x="139" y="174" width="311" height="18"/>
                                 <buttonCell key="cell" type="radio" title="Animate zoom" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="G15-Qe-p8C">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -59,7 +59,7 @@
                         <gridCell row="OOd-hD-rve" column="RqK-yY-jzI" id="ibh-ig-esN"/>
                         <gridCell row="OOd-hD-rve" column="d5q-Pb-pgU" id="1P6-Pp-b5f">
                             <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zL0-h8-cNf">
-                                <rect key="frame" x="140" y="124" width="149" height="18"/>
+                                <rect key="frame" x="139" y="150" width="153" height="18"/>
                                 <buttonCell key="cell" type="radio" title="Zoom in on selection" bezelStyle="regularSquare" imagePosition="left" inset="2" id="1V0-bu-KPz">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -71,13 +71,13 @@
                         </gridCell>
                         <gridCell row="If4-3e-uiP" column="RqK-yY-jzI" headOfMergedCell="iwB-6h-jgI" id="iwB-6h-jgI">
                             <box key="contentView" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KsN-qr-GRh">
-                                <rect key="frame" x="0.0" y="85" width="450" height="5"/>
+                                <rect key="frame" x="0.0" y="113" width="450" height="5"/>
                             </box>
                         </gridCell>
                         <gridCell row="If4-3e-uiP" column="d5q-Pb-pgU" headOfMergedCell="iwB-6h-jgI" id="UcV-H8-fjJ"/>
                         <gridCell row="R2Q-rY-cRM" column="RqK-yY-jzI" id="h2k-EF-30A">
                             <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Pwh-HF-wf6">
-                                <rect key="frame" x="-1" y="46" width="134" height="16"/>
+                                <rect key="frame" x="-1" y="74" width="134" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Default shape colour:" id="UWB-wJ-kV4">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -87,7 +87,7 @@
                         </gridCell>
                         <gridCell row="R2Q-rY-cRM" column="d5q-Pb-pgU" id="Xm6-Te-Jzh">
                             <colorWell key="contentView" translatesAutoresizingMaskIntoConstraints="NO" id="2HU-om-C7T">
-                                <rect key="frame" x="141" y="39" width="75" height="30"/>
+                                <rect key="frame" x="141" y="67" width="75" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="SSi-8a-8qj"/>
                                     <constraint firstAttribute="width" constant="75" id="US5-Mf-wy6"/>
@@ -97,7 +97,7 @@
                         </gridCell>
                         <gridCell row="ZnY-h9-dEu" column="RqK-yY-jzI" id="dHH-pO-G3q">
                             <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kdZ-Ix-AIT">
-                                <rect key="frame" x="73" y="3" width="60" height="16"/>
+                                <rect key="frame" x="73" y="31" width="60" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Nudging:" id="UN1-r8-SEh">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -107,7 +107,7 @@
                         </gridCell>
                         <gridCell row="ZnY-h9-dEu" column="d5q-Pb-pgU" id="7vR-7C-BgA">
                             <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="dW1-gQ-chh">
-                                <rect key="frame" x="141" y="0.0" width="100" height="21"/>
+                                <rect key="frame" x="141" y="28" width="100" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="rij-vW-UEb"/>
                                 </constraints>
@@ -117,6 +117,49 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                        </gridCell>
+                        <gridCell row="IHy-gl-Vqw" column="RqK-yY-jzI" id="p3c-Ej-XuJ">
+                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DFm-5v-ZoC">
+                                <rect key="frame" x="98" y="2" width="35" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Font:" id="a8Q-Mw-3Xn">
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </gridCell>
+                        <gridCell row="IHy-gl-Vqw" column="d5q-Pb-pgU" id="y99-sH-fhR">
+                            <stackView key="contentView" distribution="fill" orientation="horizontal" alignment="centerY" spacing="64" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="irX-8V-EUR">
+                                <rect key="frame" x="141" y="0.0" width="228" height="20"/>
+                                <subviews>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8LP-g5-bnE">
+                                        <rect key="frame" x="-2" y="2" width="90" height="16"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" title="SF Mono, 14.0" id="UeQ-YK-DOh">
+                                            <font key="font" usesAppearanceFont="YES"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eZz-lW-sdX">
+                                        <rect key="frame" x="143" y="-7" width="92" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Change..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="9nr-gt-gdZ">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="showFontPanel:" target="-2" id="b0A-hx-eca"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
                         </gridCell>
                     </gridCells>
                 </gridView>

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -16,6 +16,11 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 
 	var isAnimated: Bool = true
 
+	var activeViewController: NSViewController? {
+		guard let activeTab = activeTab else { return nil }
+		return preferencePanes[activeTab]
+	}
+
 	override func loadView() {
 		view = NSView()
 		view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Preferences/PreferencesTabViewController.swift
+++ b/Sources/Preferences/PreferencesTabViewController.swift
@@ -17,7 +17,10 @@ final class PreferencesTabViewController: NSViewController, PreferencesStyleCont
 	var isAnimated: Bool = true
 
 	var activeViewController: NSViewController? {
-		guard let activeTab = activeTab else { return nil }
+		guard let activeTab = activeTab else {
+			return nil
+		}
+
 		return preferencePanes[activeTab]
 	}
 

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -118,8 +118,7 @@ public final class PreferencesWindowController: NSWindowController {
 }
 
 extension PreferencesWindowController {
-
-	/// returns the active pane if it responds to the given action
+	/// Returns the active pane if it responds to the given action.
 	public override func supplementalTarget(forAction action: Selector, sender: Any?) -> Any? {
 		if let target = super.supplementalTarget(forAction: action, sender: sender) {
 			return target

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -117,6 +117,30 @@ public final class PreferencesWindowController: NSWindowController {
 	}
 }
 
+extension PreferencesWindowController {
+
+	/// returns the active pane if it responds to the given action
+	public override func supplementalTarget(forAction action: Selector, sender: Any?) -> Any? {
+		if let target = super.supplementalTarget(forAction: action, sender: sender) {
+			return target
+		}
+
+		guard let activeViewController = tabViewController.activeViewController else {
+			return nil
+		}
+
+		if let target = NSApp.target(forAction: action, to: activeViewController, from: sender) as? NSResponder, target.responds(to: action) {
+			return target
+		}
+
+		if let target = activeViewController.supplementalTarget(forAction: action, sender: sender) as? NSResponder, target.responds(to: action) {
+			return target
+		}
+
+		return nil
+	}
+}
+
 @available(macOS 10.15, *)
 extension PreferencesWindowController {
 	/**

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ If you need to respond actions indirectly, `PreferencesWindowController` will fo
 ```swift
 final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
 	@IBOutlet private var fontLabel: NSTextField!
-	private var selectedFont: NSFont = .systemFont(ofSize: 14.0)
+	private var selectedFont = NSFont.systemFont(ofSize: 14)
 
 	@IBAction private func changeFont(_ sender: NSFontManager) {
 		font = sender.convert(font)

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,19 @@ final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
 }
 ```
 
+If you need to respond actions indirectly, `PreferencesWindowController` will forward responder chain actions to the active pane if it responds to that selector.
+
+```swift
+final class AdvancedPreferenceViewController: NSViewController, PreferencePane {
+	@IBOutlet private var fontLabel: NSTextField!
+	private var selectedFont: NSFont = .systemFont(ofSize: 14.0)
+
+	@IBAction private func changeFont(_ sender: NSFontManager) {
+		font = sender.convert(font)
+	}
+}
+```
+
 In the `AppDelegate`, initialize a new `PreferencesWindowController` and pass it the view controllers. Then add an action outlet for the `Preferences…` menu item to show the preferences window.
 
 `AppDelegate.swift`


### PR DESCRIPTION
This change checks if the selected pane is a valid responder to the proposed action. It does this by overriding `supplementalTarget(forAction:sender:)` and querying if the active pane responds to the action or itself forwards a valid responder. This necessitated a change to `PreferencesTabViewController` to expose (internally) the currently active view controller.

To test this, and a valid use case, is a font based preference. `NSFontPanel` will only send a targetless `changeFont:` action when the font changes, which means you can't hook anything up in IB, etc. to intercept this message. I've added a proof-of-concept font picker button that will launch the shared font panel and will print the font manager when the font changes to illustrate the efficacy of this change.

Fixes #66 