### PR TITLE
Add the ability to set a minimum label width on containers

### DIFF
--- a/Sources/Preferences/Container.swift
+++ b/Sources/Preferences/Container.swift
@@ -18,6 +18,7 @@ extension Preferences {
 	public struct Container: View {
 		private let sectionBuilder: () -> [Section]
 		private let contentWidth: Double
+		private let minimumLabelWidth: Double
 		@State private var maxLabelWidth: CGFloat = 0.0
 
 		/**
@@ -27,14 +28,17 @@ extension Preferences {
 
 		- Parameters:
 			- contentWidth: A fixed width of the container's content (excluding paddings).
+			- minimumLabelWidth: A minimum width for labels within this container.
 			- builder: A view builder that creates `Preferences.Section`'s of this container.
 		*/
 		public init(
 			contentWidth: Double,
+			minimumLabelWidth: Double = 0.0,
 			@SectionBuilder builder: @escaping () -> [Section]
 		) {
 			self.sectionBuilder = builder
 			self.contentWidth = contentWidth
+			self.minimumLabelWidth = minimumLabelWidth
 		}
 
 		public var body: some View {
@@ -58,7 +62,7 @@ extension Preferences {
 				Divider()
 					// Strangely doesn't work without width being specified. Probably because of custom alignment.
 					.frame(width: CGFloat(contentWidth), height: 20.0)
-					.alignmentGuide(.preferenceSectionLabel) { $0[.leading] + maxLabelWidth }
+					.alignmentGuide(.preferenceSectionLabel) { $0[.leading] + max(minimumLabelWidth, maxLabelWidth) }
 			}
 		}
 	}

--- a/Sources/Preferences/Container.swift
+++ b/Sources/Preferences/Container.swift
@@ -28,12 +28,12 @@ extension Preferences {
 
 		- Parameters:
 			- contentWidth: A fixed width of the container's content (excluding paddings).
-			- minimumLabelWidth: A minimum width for labels within this container.
+			- minimumLabelWidth: A minimum width for labels within this container. Defaults to `0`, which behaves as if there is no minimum width set for labels.
 			- builder: A view builder that creates `Preferences.Section`'s of this container.
 		*/
 		public init(
 			contentWidth: Double,
-			minimumLabelWidth: Double = 0.0,
+			minimumLabelWidth: Double = 0,
 			@SectionBuilder builder: @escaping () -> [Section]
 		) {
 			self.sectionBuilder = builder

--- a/Sources/Preferences/Container.swift
+++ b/Sources/Preferences/Container.swift
@@ -28,7 +28,7 @@ extension Preferences {
 
 		- Parameters:
 			- contentWidth: A fixed width of the container's content (excluding paddings).
-			- minimumLabelWidth: A minimum width for labels within this container. Defaults to `0`, which behaves as if there is no minimum width set for labels.
+			- minimumLabelWidth: A minimum width for labels within this container. By default, it will fit to the largest label.
 			- builder: A view builder that creates `Preferences.Section`'s of this container.
 		*/
 		public init(


### PR DESCRIPTION
This PR proposes to add a new `minimumLabelWidth` parameter to `Container` instances. 

I've found in my own preference panes, that the automatically calculated width for labels can be a bit tight, especially for wider panes. 