### PR TITLE
SwiftUI content change resize animation example

### DIFF
--- a/Example/AccountsScreen.swift
+++ b/Example/AccountsScreen.swift
@@ -29,7 +29,7 @@ struct AccountsScreen: View {
 	@State private var selection1 = 1
 	@State private var selection2 = 0
 	@State private var selection3 = 0
-	@State private var expand = false
+	@State private var isExpanded = false
 	private let contentWidth: Double = 450.0
 
 	var body: some View {
@@ -70,20 +70,19 @@ struct AccountsScreen: View {
 				Text("Automatic mode can slow things down.")
 					.preferenceDescription()
 			}
-			
-			Settings.Section(title: "Expand this pane:"){
+			Settings.Section(title: "Expand this pane:") {
 				Toggle("Expand", isOn: $expand)
-				
-				if(expand){
-					ZStack(alignment: .center, content: {
+				if isExpanded {
+					ZStack(alignment: .center) {
 						Rectangle()
 							.fill(.gray)
 							.frame(width: 200, height: 200)
 							.cornerRadius(20)
-						
 						Text("It would be nice if the window would animate based on the size of the content :)")
-							.frame(width: 180, height: 180).multilineTextAlignment(.center).colorInvert()
-					})
+							.frame(width: 180, height: 180)
+							.multilineTextAlignment(.center)
+							.colorInvert()
+					}
 				}
 			}
 		}

--- a/Example/AccountsScreen.swift
+++ b/Example/AccountsScreen.swift
@@ -71,17 +71,15 @@ struct AccountsScreen: View {
 					.preferenceDescription()
 			}
 			Settings.Section(title: "Expand this pane:") {
-				Toggle("Expand", isOn: $expand)
+				Toggle("Expand", isOn: $isExpanded)
 				if isExpanded {
 					ZStack(alignment: .center) {
 						Rectangle()
 							.fill(.gray)
 							.frame(width: 200, height: 200)
 							.cornerRadius(20)
-						Text("It would be nice if the window would animate based on the size of the content :)")
+						Text("🦄")
 							.frame(width: 180, height: 180)
-							.multilineTextAlignment(.center)
-							.colorInvert()
 					}
 				}
 			}

--- a/Example/AccountsScreen.swift
+++ b/Example/AccountsScreen.swift
@@ -29,6 +29,7 @@ struct AccountsScreen: View {
 	@State private var selection1 = 1
 	@State private var selection2 = 0
 	@State private var selection3 = 0
+	@State private var expand = false
 	private let contentWidth: Double = 450.0
 
 	var body: some View {
@@ -68,6 +69,22 @@ struct AccountsScreen: View {
 					.frame(width: 120.0)
 				Text("Automatic mode can slow things down.")
 					.preferenceDescription()
+			}
+			
+			Settings.Section(title: "Expand this pane:"){
+				Toggle("Expand", isOn: $expand)
+				
+				if(expand){
+					ZStack(alignment: .center, content: {
+						Rectangle()
+							.fill(.gray)
+							.frame(width: 200, height: 200)
+							.cornerRadius(20)
+						
+						Text("It would be nice if the window would animate based on the size of the content :)")
+							.frame(width: 180, height: 180).multilineTextAlignment(.center).colorInvert()
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
modified the accounts pane in the example app to show that the window does not animate the resize when the content size changes in SwiftUI